### PR TITLE
Improve Error Info UX

### DIFF
--- a/server/frontend/src/PyProcessUI.tsx
+++ b/server/frontend/src/PyProcessUI.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren, useCallback, useEffect, useState } from "reac
 import { PyProcess, PyProcessState } from "./PyProcess";
 import useWebSocket from "./useWebSocket";
 import { parseJsonMessage } from "./Message";
+import { StdErrMessage } from "./StdErrMessage";
 
 interface PyProcessUIProps {
     pyProcess: PyProcess
@@ -135,7 +136,7 @@ export function PyProcessUI(props: PropsWithChildren<PyProcessUIProps>) {
                 case 'stdout':
                     return <p key={idx}>{line.line}</p>
                 case 'stderr':
-                    return <p key={idx} className="text-error">{line.line}</p>
+                    return <StdErrMessage key={idx} line={line.line} />;
             }
         })}
     </div>;

--- a/server/frontend/src/StdErrMessage.tsx
+++ b/server/frontend/src/StdErrMessage.tsx
@@ -1,0 +1,98 @@
+interface StdErrProps {
+    line: string;
+}
+
+interface StackTrace {
+    type?: string;
+    message: string;
+    stack_trace: StackFrame[];
+}
+
+interface StackFrame {
+    filename: string;
+    lineno: number;
+    name: string;
+    line: string;
+    end_lineno: number;
+    colno: number;
+    end_colno: number;
+    locals: { [key: string]: any };
+}
+
+function valueToJSX(value: any): JSX.Element {
+    if (typeof value === 'boolean') {
+        return <span>{value ? 'True' : 'False'}</span>;
+    } else if (typeof value === 'string') {
+        return <span>"{value}"</span>
+    } else if (typeof value === 'object') {
+        if (value instanceof Array) {
+            return <span>{JSON.stringify(value)}</span>
+        } else if (value instanceof Object && value.hasOwnProperty('type')) {
+            return <div>
+                <div><strong>{value.type}</strong> Object (See in Debugger)</div>
+            </div>
+        }
+    }
+    return <span>{JSON.stringify(value)}</span>;
+}
+
+export function StdErrMessage(props: React.PropsWithChildren<StdErrProps>) {
+    try {
+        const message = JSON.parse(props.line) as StackTrace;
+        console.log(message);
+
+        const lastIndex = message.stack_trace.length - 1;
+
+        const frames = message.stack_trace.map((frame, index) => {
+            let className = "collapse bg-base-200 mt-2";
+            if (index !== lastIndex) {
+                className += " collapse-arrow";
+            } else {
+                className += " collapse-open";
+            }
+            return <div className={className} key={index}>
+                <input type="checkbox" />
+                <div className="collapse-title font-bold text-secondary">
+                    {frame.name.replace('<module>', 'Globals')}
+                    <span className="font-light text-white italic pl-2 opacity-40">{frame.filename} line {frame.lineno}</span>
+                </div>
+                <div className="collapse-content">
+                    <pre>
+                        {frame.lineno.toString().padStart(4, " ")} | {frame.line}
+                        {" ".repeat(7 + frame.colno) + "^".repeat(frame.end_colno - frame.colno) + "\n"}
+                        {index !== lastIndex ? "" : `${message.type}: ${message.message}`}
+                    </pre>
+                    <table className="table m-0 table-fixed">
+                        <thead>
+                            <tr>
+                                <th className="w-36">Variable</th>
+                                <th>Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {Object.keys(frame.locals).map((key, index) => {
+                                return <tr key={index}>
+                                    <td className="font-mono">{key}</td>
+                                    <td className="font-mono">{valueToJSX(frame.locals[key])}</td>
+                                </tr>
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            </div>;
+        });
+
+        if (message.type) {
+            return <div className="rounded-box bg-error p-4">
+                <h3 className="mt-0 text-error-content font-black">{message.type}: {message.message}</h3>
+                <h4 className="text-error-content">Stack</h4>
+                {frames}
+            </div>;
+        } else {
+            return <p className="text-error">{props.line}</p>
+        }
+    } catch (e) {
+        return <p className="text-error">{props.line}</p>
+    }
+
+}

--- a/server/wrappers/module.py
+++ b/server/wrappers/module.py
@@ -34,17 +34,41 @@ except Exception as e:
         frame = info_frames[i]
         stack_frame = stack_frames[i]
 
-        if frame.filename.startswith("/workspace/server") or frame.filename.startswith(
-            "/usr/lib"
+        if (
+            frame.filename.startswith("/workspace/server")
+            or frame.filename.startswith("/usr/lib")
+            or frame.filename.startswith("<frozen importlib")
         ):
             continue
 
+        arguments = inspect.getargvalues(stack_frame.frame)
+
         locals: dict[str, Any] = {}
         for local in stack_frame.frame.f_locals:
+            value = stack_frame.frame.f_locals[local]
             try:
-                json.dumps(stack_frame.frame.f_locals[local])
-                locals[local] = stack_frame.frame.f_locals[local]
+                json.dumps(value)
+                locals[local] = value
+                # except (TypeError, OverflowError):
+                #     try:
+                #         value_type = type(value)
+
+                #             attributes = [
+                #                 attr for attr in dir(value) if not attr.startswith("_")
+                #             ]
+                #             simple_object: dict[str, Any] = {}
+
+                #             for attr in attributes:
+                #                 simple_object[attr] = getattr(value, attr)
+
+                #             locals[local] = {
+                #                 "type": type(value).__name__,
+                #                 "repr": attributes,
+                #             }
+                #         else:
+                #             locals[local] = repr(value)
             except (TypeError, OverflowError):
+                locals[local] = "[See value in Debugger]"
                 continue
 
         stack_trace.append(
@@ -52,7 +76,7 @@ except Exception as e:
                 "filename": frame.filename.replace("/workspace/", ""),
                 "lineno": frame.lineno,
                 "name": frame.name,
-                "line": frame.line,
+                "line": "".join(stack_frame.code_context),  # type: ignore
                 "end_lineno": frame.end_lineno,
                 "colno": frame.colno,
                 "end_colno": frame.end_colno,
@@ -68,5 +92,5 @@ except Exception as e:
 
     json_error_info = json.dumps(error_info)
 
-    sys.stderr.write(json_error_info + "\n")
+    sys.stderr.write(f"{json_error_info}\n")
     sys.exit(1)


### PR DESCRIPTION
This PR introduces some error handling into the wrapper that emits JSON to stderr such that the frontend can render an error experience like:

<img width="677" alt="Screenshot 2023-12-26 at 3 23 46 PM" src="https://github.com/KrisJordan/comp110-24s/assets/31329/797f4c5c-0340-4ac6-a944-b554917764f1">

There are still many rough edges to sort out, which will be created as Issues, but this offers a baseline to iterate off of.