### PR TITLE
Fix npm reported vulnerabilities

### DIFF
--- a/server/frontend/package-lock.json
+++ b/server/frontend/package-lock.json
@@ -8,13 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "localforage": "^1.10.0",
-        "match-sorter": "^6.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.1",
-        "react-use-websocket": "^4.5.0",
-        "sort-by": "^0.0.2"
+        "react-use-websocket": "^4.5.0"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.10",
@@ -362,17 +359,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
-      "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2616,11 +2602,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2848,14 +2829,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -2870,14 +2843,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "dependencies": {
-        "lie": "3.1.1"
-      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -2930,15 +2895,6 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
       }
     },
     "node_modules/merge2": {
@@ -3514,16 +3470,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -3709,11 +3655,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/sort-by": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-0.0.2.tgz",
-      "integrity": "sha512-iOX5oHA4a0eqTMFiWrHYqv924UeRKFBLhym7iwSVG37Egg2wApgZKAjyzM9WZjMwKv6+8Zi+nIaJ7FYsO9EkoA=="
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",

--- a/server/frontend/package-lock.json
+++ b/server/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.1",
         "react-use-websocket": "^4.5.0",
-        "sort-by": "^1.2.0"
+        "sort-by": "^0.0.2"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.10",
@@ -3067,14 +3067,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/object-path": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz",
-      "integrity": "sha512-fxrwsCFi3/p+LeLOAwo/wyRMODZxdGBtUlWRzsEpsUVrisZbEfZ21arxLGfaWfcnqb8oHPNihIb4XPE8CQPN5A==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3719,12 +3711,9 @@
       }
     },
     "node_modules/sort-by": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-1.2.0.tgz",
-      "integrity": "sha512-aRyW65r3xMnf4nxJRluCg0H/woJpksU1dQxRtXYzau30sNBOmf5HACpDd9MZDhKh7ALQ5FgSOfMPwZEtUmMqcg==",
-      "dependencies": {
-        "object-path": "0.6.0"
-      }
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-0.0.2.tgz",
+      "integrity": "sha512-iOX5oHA4a0eqTMFiWrHYqv924UeRKFBLhym7iwSVG37Egg2wApgZKAjyzM9WZjMwKv6+8Zi+nIaJ7FYsO9EkoA=="
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",

--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
     "react-use-websocket": "^4.5.0",
-    "sort-by": "^1.2.0"
+    "sort-by": "^0.0.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",

--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -10,13 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "localforage": "^1.10.0",
-    "match-sorter": "^6.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
-    "react-use-websocket": "^4.5.0",
-    "sort-by": "^0.0.2"
+    "react-use-websocket": "^4.5.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",


### PR DESCRIPTION
@noahsmiths after running `npm -i` a few vulnerabilities were reported. I let `npm audit` fix them and the suggested fix is apparently downgrading `sort-by` to `0.0.2`? Does this break anything on your end?