### PR TITLE
Slight refactoring to include new StdOutGroupContainer component

### DIFF
--- a/server/frontend/src/StdIOTypes.ts
+++ b/server/frontend/src/StdIOTypes.ts
@@ -1,0 +1,24 @@
+export type StdOut = {
+    type: 'stdout';
+    line: string;
+}
+
+export type StdErr = {
+    type: 'stderr';
+    line: string;
+}
+
+export type StdIn = {
+    type: 'stdin';
+    prompt: string;
+    response?: string;
+}
+
+export type StdOutGroup = {
+    type: 'stdout_group';
+    children: StdOut[];
+    endTime: number;
+    startTime: number;
+}
+
+export type StdIO = StdErr | StdIn | StdOutGroup;

--- a/server/frontend/src/StdOutGroupContainer.tsx
+++ b/server/frontend/src/StdOutGroupContainer.tsx
@@ -1,0 +1,42 @@
+import { PropsWithChildren, useState } from "react";
+import { StdOutGroup, StdOut } from "./StdIOTypes";
+
+interface StdOutProps {
+    group: StdOutGroup,
+    minGroupSize: number,
+    groupAfterRatePerSecond: number
+}
+
+export function StdOutGroupContainer(props: PropsWithChildren<StdOutProps>) {
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+
+    const stdoutGroup = props.group;
+    const lines = stdoutGroup.children;
+    const convertedRatePerMS = props.groupAfterRatePerSecond / 1000;
+    const shouldCollapse =
+        lines.length >= props.minGroupSize
+        && (lines.length / (stdoutGroup.endTime - stdoutGroup.startTime)) > convertedRatePerMS;
+
+    function stdOutLine(childLine: StdOut, idx: number) {
+        return <p key={idx}>{childLine.line}</p>
+    };
+
+    return <>
+        {
+            shouldCollapse
+                ? <div>
+                    {lines.slice(0, 2).map(stdOutLine)}
+                    <p onClick={() => { setIsOpen(current => !current) }} className="hover:cursor-pointer">
+                        {
+                            isOpen
+                                ? <>Hide lower <strong>{lines.length - 4}</strong> lines</>
+                                : <><strong>{lines.length - 4}</strong> additional lines hidden</>
+                        }
+                    </p>
+                    {isOpen && lines.slice(2, lines.length - 2).map(stdOutLine)}
+                    {lines.slice(lines.length - 2).map(stdOutLine)}
+                </div>
+                : lines.map(stdOutLine)
+        }
+    </>;
+}


### PR DESCRIPTION
I moved the StdIO types previously in PyProcessUI to their own type file, as they're shared somewhat between the new StdOutGroupContainer component and PyProcessUI.

StdOutGroupContainer has some configurable props, which at the moment are set to group after 10 messages if they're coming through at a rate of more than 10 per second.

Also, the container handles collapsing now through it's own state, so lines are completely excluded from the DOM if the group is collapsed, instead of just hidden like before.